### PR TITLE
releasetools: Use the first entry of a mount point when reading fstab

### DIFF
--- a/tools/releasetools/common.py
+++ b/tools/releasetools/common.py
@@ -268,9 +268,10 @@ def LoadRecoveryFSTab(read_helper, fstab_version, type):
           else:
             print("%s: unknown option \"%s\"" % (mount_point, i))
 
-      d[mount_point] = Partition(mount_point=mount_point, fs_type=pieces[1],
-                                 device=pieces[2], length=length,
-                                 device2=device2)
+      if not d.get(mount_point):
+          d[mount_point] = Partition(mount_point=mount_point, fs_type=pieces[1],
+                                     device=pieces[2], length=length,
+                                     device2=device2)
 
   elif fstab_version == 2:
     d = {}
@@ -306,9 +307,10 @@ def LoadRecoveryFSTab(read_helper, fstab_version, type):
           context = i
 
       mount_point = pieces[1]
-      d[mount_point] = Partition(mount_point=mount_point, fs_type=pieces[2],
-                                 device=pieces[0], length=length,
-                                 device2=None, context=context)
+      if not d.get(mount_point):
+          d[mount_point] = Partition(mount_point=mount_point, fs_type=pieces[2],
+                                     device=pieces[0], length=length,
+                                     device2=None, context=context)
 
   else:
     raise ValueError("Unknown fstab_version: \"%d\"" % (fstab_version,))


### PR DESCRIPTION
There may be multiple entries in fstab for a mount point. Use the first
value found so the entries are prioritized in order.

Change-Id: Ibd2631413d3e00507d3a0ec84fb91755f1c7993c
Ticket: OPO-326
