### PR TITLE
binary: Generate dummy rule for relocated protobuf headers

### DIFF
--- a/core/binary.mk
+++ b/core/binary.mk
@@ -566,6 +566,17 @@ $(proto_generated_headers): $(proto_generated_sources_dir)/%.pb.h: $(proto_gener
 	$(hide) touch $@
 	$(copy-proto-files)
 
+$(if $(LOCAL_PROTOC_OUTPUT), \
+$(if $(call streq,$(LOCAL_PROTOC_OUTPUT),$(LOCAL_PATH)),, \
+  $(eval proto_relocated_headers := $(subst $(LOCAL_PATH),$(LOCAL_PROTOC_OUTPUT),$(proto_generated_headers))) \
+ ), )
+
+ifdef proto_relocated_headers
+$(proto_relocated_headers): $(proto_generated_headers)
+	echo "Refreshed header file $@."
+	$(hide) touch $@
+endif
+
 $(my_prefix)_$(LOCAL_MODULE_CLASS)_$(LOCAL_MODULE)_proto_defined := true
 endif  # transform-proto-to-cc rule included only once
 


### PR DESCRIPTION
Similar to (and dependent on) the rule already in place for pb
headers, to avoid dependency breakage when builds are interrupted
for random reasons

Change-Id: Ie88f468f8a5b0d240121db6791a1053c4a7c5bfb
