### PR TITLE
build: allow to set a consumer proguard file

### DIFF
--- a/core/static_java_library.mk
+++ b/core/static_java_library.mk
@@ -140,6 +140,7 @@ $(built_aar): PRIVATE_ANDROID_MANIFEST := $(full_android_manifest)
 $(built_aar): PRIVATE_CLASSES_JAR := $(LOCAL_BUILT_MODULE)
 $(built_aar): PRIVATE_RESOURCE_DIR := $(LOCAL_RESOURCE_DIR)
 $(built_aar): PRIVATE_R_TXT := $(LOCAL_INTERMEDIATE_SOURCE_DIR)/R.txt
+$(built_aar): PRIVATE_CONSUMER_PROGUARD_FILE := $(LOCAL_CONSUMER_PROGUARD_FILE)
 $(built_aar) : $(LOCAL_BUILT_MODULE)
 	@echo "target AAR:  $(PRIVATE_MODULE) ($@)"
 	$(hide) rm -rf $(dir $@)aar && mkdir -p $(dir $@)aar/res
@@ -148,6 +149,9 @@ $(built_aar) : $(LOCAL_BUILT_MODULE)
 	# Note: Use "cp -n" to honor the resource overlay rules, if multiple res dirs exist.
 	$(hide) $(foreach res,$(PRIVATE_RESOURCE_DIR),cp -Rfn $(res)/* $(dir $@)aar/res;)
 	$(hide) cp $(PRIVATE_R_TXT) $(dir $@)aar/R.txt
+ifneq ($(PRIVATE_CONSUMER_PROGUARD_FILE),)
+	$(hide) cp $(PRIVATE_CONSUMER_PROGUARD_FILE) $(dir $@)aar/proguard.txt
+endif
 	$(hide) jar -cMf $@ \
 	  -C $(dir $@)aar .
 


### PR DESCRIPTION
This allow to specify a proguard file by defining LOCAL_CONSUMER_PROGUARD_FILE
that will inserted in the root directory of the aar and to be consumed by another apk
via gradle plugin

Change-Id: Ia3c11e5ea8e694800fb262b835432f86a6777f86
Signed-off-by: Jorge Ruesga jorge@ruesga.com
